### PR TITLE
fix: update login redirection to ensure session cookie recognition

### DIFF
--- a/src/modules/auth/components/login-form.tsx
+++ b/src/modules/auth/components/login-form.tsx
@@ -45,7 +45,9 @@ export function LoginForm() {
 		login(credentials, {
 			onSuccess: () => {
 				const redirectTo = searchParams.get('redirect') || '/'
-				router.push(redirectTo)
+				// Use window.location.href for a full page reload to ensure
+				// the middleware properly recognizes the new session cookie
+				window.location.href = redirectTo
 			},
 			onError: ({ response }) => {
 				if (response?.data.message) setApiError(response.data.message)


### PR DESCRIPTION
- Change redirection method in LoginForm from router.push to window.location.href for a full page reload.
- This adjustment ensures that the middleware properly recognizes the new session cookie after login.